### PR TITLE
Fix/osx10.9

### DIFF
--- a/lemon.cmake
+++ b/lemon.cmake
@@ -32,8 +32,9 @@ ExternalProject_Add(${lemon_NAME}
     UPDATE_COMMAND      ""
     PATCH_COMMAND       ${BUILDEM_ENV_STRING} ${PATCH_EXE}
         # This patch fixes a build error that clang detects.
-        # (Already fixed in lemon trunk, but not in the tarball release.)
+        # Already fixed in lemon trunk, patch here in Ticket #480 ( https://lemon.cs.elte.hu/trac/lemon/attachment/ticket/480/51deaff8728a.patch ), but not in the tarball release.
     	${lemon_SRC_DIR}/lemon/graph_to_eps.h ${PATCH_DIR}/lemon.patch
+        ${lemon_SRC_DIR}/tools/lgf-gen.cc ${PATCH_DIR}/lemon-lgf-gen.patch
     	# Apparently one test file is missing from the release.
     	# This patch removes it from CMakeLists.txt
         ${lemon_SRC_DIR}/test/CMakeLists.txt ${PATCH_DIR}/lemon-test.patch

--- a/openblas.cmake
+++ b/openblas.cmake
@@ -10,7 +10,8 @@ include (ExternalProject)
 include (ExternalSource)
 
 external_git_repo (openblas
-    v0.2.8
+    #v0.2.8
+    HEAD
     https://github.com/xianyi/OpenBLAS)
 
 message ("Installing ${openblas_NAME} into ilastik build area: ${BUILDEM_DIR} ...")
@@ -22,9 +23,11 @@ ExternalProject_Add(${openblas_NAME}
     UPDATE_COMMAND      ""
     PATCH_COMMAND       ""
     CONFIGURE_COMMAND   ""
-    BUILD_COMMAND       $(MAKE) NO_AVX=1 NO_AFFINITY=1 -j8
+    # Added Sandybridge target. This is required for SandyBridge architecture. It also will optimize for Haswell architechture, which includes Clearwell.
+    BUILD_COMMAND       ${BUILDEM_ENV_STRING} $(MAKE) NO_AVX=1 NO_AFFINITY=1 TARGET=SANDYBRIDGE -j8
     BUILD_IN_SOURCE     1
-    INSTALL_COMMAND     $(MAKE) PREFIX=${BUILDEM_DIR} install &&
+    # Added Sandybridge target. This is required for SandyBridge architecture. It also will optimize for Haswell architechture, which includes Clearwell.
+    INSTALL_COMMAND     ${BUILDEM_ENV_STRING} $(MAKE) PREFIX=${BUILDEM_DIR} TARGET=SANDYBRIDGE install &&
                         ln -fs libopenblas.so ${BUILDEM_DIR}/lib/libblas.so &&
                         ln -fs libopenblas.so ${BUILDEM_DIR}/lib/liblapack.so
 )

--- a/patches/lemon-lgf-gen.patch
+++ b/patches/lemon-lgf-gen.patch
@@ -1,0 +1,108 @@
+# HG changeset patch
+# User Alpar Juttner <alpar@cs.elte.hu>
+# Date 1396968869 -7200
+#      Tue Apr 08 16:54:29 2014 +0200
+# Node ID 51deaff8728aacb20463ace3626807877d608611
+# Parent  e00d7b681d8e8fa6cc94353e9b30388b27138043
+Clang compatibility fix in lgf-gen.cc (#480)
+
+diff --git a/tools/lgf-gen.cc b/tools/lgf-gen.cc
+--- a/tools/lgf-gen.cc
++++ b/tools/lgf-gen.cc
+@@ -246,7 +246,7 @@
+ 
+   struct BeachIt;
+ 
+-  typedef std::multimap<double, BeachIt> SpikeHeap;
++  typedef std::multimap<double, BeachIt*> SpikeHeap;
+ 
+   typedef std::multimap<Part, SpikeHeap::iterator, YLess> Beach;
+ 
+@@ -329,6 +329,7 @@
+       Beach::iterator bit = beach.upper_bound(Part(site, site, site));
+ 
+       if (bit->second != spikeheap.end()) {
++        delete bit->second->second;
+         spikeheap.erase(bit->second);
+       }
+ 
+@@ -342,8 +343,8 @@
+       if (prev != -1 &&
+           circle_form(points[prev], points[curr], points[site])) {
+         double x = circle_point(points[prev], points[curr], points[site]);
+-        pit = spikeheap.insert(std::make_pair(x, BeachIt(beach.end())));
+-        pit->second.it =
++        pit = spikeheap.insert(std::make_pair(x, new BeachIt(beach.end())));
++        pit->second->it =
+           beach.insert(std::make_pair(Part(prev, curr, site), pit));
+       } else {
+         beach.insert(std::make_pair(Part(prev, curr, site), pit));
+@@ -355,8 +356,8 @@
+       if (next != -1 &&
+           circle_form(points[site], points[curr],points[next])) {
+         double x = circle_point(points[site], points[curr], points[next]);
+-        nit = spikeheap.insert(std::make_pair(x, BeachIt(beach.end())));
+-        nit->second.it =
++        nit = spikeheap.insert(std::make_pair(x, new BeachIt(beach.end())));
++        nit->second->it =
+           beach.insert(std::make_pair(Part(site, curr, next), nit));
+       } else {
+         beach.insert(std::make_pair(Part(site, curr, next), nit));
+@@ -366,7 +367,7 @@
+     } else {
+       sweep = spit->first;
+ 
+-      Beach::iterator bit = spit->second.it;
++      Beach::iterator bit = spit->second->it;
+ 
+       int prev = bit->first.prev;
+       int curr = bit->first.curr;
+@@ -399,10 +400,22 @@
+       Beach::iterator nbit = bit; ++nbit;
+       int nnt = nbit->first.next;
+ 
+-      if (bit->second != spikeheap.end()) spikeheap.erase(bit->second);
+-      if (pbit->second != spikeheap.end()) spikeheap.erase(pbit->second);
+-      if (nbit->second != spikeheap.end()) spikeheap.erase(nbit->second);
+-
++      if (bit->second != spikeheap.end())
++        {
++          delete bit->second->second;
++          spikeheap.erase(bit->second);
++        }
++      if (pbit->second != spikeheap.end())
++        {
++          delete pbit->second->second;
++          spikeheap.erase(pbit->second);
++        }
++      if (nbit->second != spikeheap.end())
++        {
++          delete nbit->second->second;
++          spikeheap.erase(nbit->second);
++        }
++      
+       beach.erase(nbit);
+       beach.erase(bit);
+       beach.erase(pbit);
+@@ -412,8 +425,8 @@
+           circle_form(points[ppv], points[prev], points[next])) {
+         double x = circle_point(points[ppv], points[prev], points[next]);
+         if (x < sweep) x = sweep;
+-        pit = spikeheap.insert(std::make_pair(x, BeachIt(beach.end())));
+-        pit->second.it =
++        pit = spikeheap.insert(std::make_pair(x, new BeachIt(beach.end())));
++        pit->second->it =
+           beach.insert(std::make_pair(Part(ppv, prev, next), pit));
+       } else {
+         beach.insert(std::make_pair(Part(ppv, prev, next), pit));
+@@ -424,8 +437,8 @@
+           circle_form(points[prev], points[next], points[nnt])) {
+         double x = circle_point(points[prev], points[next], points[nnt]);
+         if (x < sweep) x = sweep;
+-        nit = spikeheap.insert(std::make_pair(x, BeachIt(beach.end())));
+-        nit->second.it =
++        nit = spikeheap.insert(std::make_pair(x, new BeachIt(beach.end())));
++        nit->second->it =
+           beach.insert(std::make_pair(Part(prev, next, nnt), nit));
+       } else {
+         beach.insert(std::make_pair(Part(prev, next, nnt), nit));

--- a/patches/pyqt4.patch
+++ b/patches/pyqt4.patch
@@ -1,0 +1,24 @@
+--- configure.py	2013-08-21 02:02:48.000000000 -0400
++++ configure_2.py	2014-04-11 16:11:07.000000000 -0400
+@@ -371,8 +371,8 @@
+         check_module("QtTest", "QtTest", "QTest::qSleep(0)")
+         check_module("QtWebKit", "qwebpage.h", "new QWebPage()")
+         check_module("QtXmlPatterns", "qxmlname.h", "new QXmlName()")
+-        check_module("phonon", "phonon/videowidget.h",
+-                "new Phonon::VideoWidget()")
++#        check_module("phonon", "phonon/videowidget.h",
++#                "new Phonon::VideoWidget()")
+         check_module("QtAssistant", "qassistantclient.h",
+                 "new QAssistantClient(\"foo\")", extra_lib_dirs=ass_lib_dirs,
+                 extra_libs=ass_libs)
+@@ -518,8 +518,8 @@
+         if "QtXmlPatterns" in pyqt_modules:
+             generate_code("QtXmlPatterns")
+ 
+-        if "phonon" in pyqt_modules:
+-            generate_code("phonon")
++        #if "phonon" in pyqt_modules:
++        #    generate_code("phonon")
+ 
+         if "QtAssistant" in pyqt_modules:
+             generate_code("QtAssistant")

--- a/patches/qt4-osx-mavericks-configure.patch
+++ b/patches/qt4-osx-mavericks-configure.patch
@@ -1,0 +1,21 @@
+--- ilastik_build_dir_2/src/qt4-git/configure	2014-04-11 17:46:22.000000000 -0400
++++ ilastik_build_dir/src/qt4-git/configure	2014-04-11 17:31:32.000000000 -0400
+@@ -7993,10 +7993,14 @@
+             QMakeVar add QMAKE_OBJECTIVE_CFLAGS_PPC "-arch ppc -Xarch_ppc -mmacosx-version-min=10.4"
+         fi
+         if echo "$CFG_MAC_ARCHS" | grep '\<x86_64\>' > /dev/null 2>&1; then
+-            QMakeVar add QMAKE_CFLAGS "-Xarch_x86_64 -mmacosx-version-min=10.5"
+-            QMakeVar add QMAKE_CXXFLAGS "-Xarch_x86_64 -mmacosx-version-min=10.5"
+-            QMakeVar add QMAKE_LFLAGS "-Xarch_x86_64 -mmacosx-version-min=10.5"
+-            QMakeVar add QMAKE_OBJECTIVE_CFLAGS_X86_64 "-arch x86_64 -Xarch_x86_64 -mmacosx-version-min=10.5"
++#            QMakeVar add QMAKE_CFLAGS "-Xarch_x86_64 -mmacosx-version-min=10.5"
++#            QMakeVar add QMAKE_CXXFLAGS "-Xarch_x86_64 -mmacosx-version-min=10.5"
++#            QMakeVar add QMAKE_LFLAGS "-Xarch_x86_64 -mmacosx-version-min=10.5"
++#            QMakeVar add QMAKE_OBJECTIVE_CFLAGS_X86_64 "-arch x86_64 -Xarch_x86_64 -mmacosx-version-min=10.5"
++            QMakeVar add QMAKE_CFLAGS "-mmacosx-version-min=10.5"
++            QMakeVar add QMAKE_CXXFLAGS "-mmacosx-version-min=10.5"
++            QMakeVar add QMAKE_LFLAGS "-mmacosx-version-min=10.5"
++            QMakeVar add QMAKE_OBJECTIVE_CFLAGS_X86_64 "-arch x86_64 -mmacosx-version-min=10.5"
+         fi
+         if echo "$CFG_MAC_ARCHS" | grep '\<ppc64\>' > /dev/null 2>&1; then
+             QMakeVar add QMAKE_CFLAGS "-Xarch_ppc64 -mmacosx-version-min=10.5"

--- a/patches/qt4-osx-mavericks-gui-pro.patch
+++ b/patches/qt4-osx-mavericks-gui-pro.patch
@@ -1,0 +1,77 @@
+--- ilastik_build_dir_2/src/qt4-git/src/gui/gui.pro	2014-04-11 17:46:26.000000000 -0400
++++ ilastik_build_dir/src/qt4-git/src/gui/gui.pro	2014-04-11 17:31:23.000000000 -0400
+@@ -95,8 +95,9 @@
+             mmx_compiler.commands = $$QMAKE_CXX -c -Winline
+ 
+             mac {
+-                mmx_compiler.commands += -Xarch_i386 -mmmx
+-                mmx_compiler.commands += -Xarch_x86_64 -mmmx
++#                mmx_compiler.commands += -Xarch_i386 -mmmx
++#                mmx_compiler.commands += -Xarch_x86_64 -mmmx
++                 mmx_compiler.commands += -mmmx
+             } else {
+                 mmx_compiler.commands += -mmmx
+             }
+@@ -114,8 +115,9 @@
+             mmx3dnow_compiler.commands = $$QMAKE_CXX -c -Winline
+ 
+             mac {
+-                mmx3dnow_compiler.commands += -Xarch_i386 -m3dnow -Xarch_i386 -mmmx
+-                mmx3dnow_compiler.commands += -Xarch_x86_64 -m3dnow -Xarch_x86_64 -mmmx
++#                mmx3dnow_compiler.commands += -Xarch_i386 -m3dnow -Xarch_i386 -mmmx
++#                mmx3dnow_compiler.commands += -Xarch_x86_64 -m3dnow -Xarch_x86_64 -mmmx
++                 mmx3dnow_compiler.commands += -m3dnow -mmmx
+             } else {
+                 mmx3dnow_compiler.commands += -m3dnow -mmmx
+             }
+@@ -132,8 +134,9 @@
+                 sse3dnow_compiler.commands = $$QMAKE_CXX -c -Winline
+ 
+                 mac {
+-                    sse3dnow_compiler.commands += -Xarch_i386 -m3dnow -Xarch_i386 -msse
+-                    sse3dnow_compiler.commands += -Xarch_x86_64 -m3dnow -Xarch_x86_64 -msse
++#                    sse3dnow_compiler.commands += -Xarch_i386 -m3dnow -Xarch_i386 -msse
++#                    sse3dnow_compiler.commands += -Xarch_x86_64 -m3dnow -Xarch_x86_64 -msse
++                    sse3dnow_compiler.commands += -m3dnow -msse
+                 } else {
+                     sse3dnow_compiler.commands += -m3dnow -msse
+                 }
+@@ -152,8 +155,10 @@
+             sse_compiler.commands = $$QMAKE_CXX -c -Winline
+ 
+             mac {
+-                sse_compiler.commands += -Xarch_i386 -msse
+-                sse_compiler.commands += -Xarch_x86_64 -msse
++#                sse_compiler.commands += -Xarch_i386 -msse
++#                sse_compiler.commands += -Xarch_x86_64 -msse
++                sse_compiler.commands += -msse
++                sse_compiler.commands += -msse
+             } else {
+                 sse_compiler.commands += -msse
+             }
+@@ -171,8 +176,10 @@
+             sse2_compiler.commands = $$QMAKE_CXX -c -Winline
+ 
+             mac {
+-                sse2_compiler.commands += -Xarch_i386 -msse2
+-                sse2_compiler.commands += -Xarch_x86_64 -msse2
++#                sse2_compiler.commands += -Xarch_i386 -msse2
++#                sse2_compiler.commands += -Xarch_x86_64 -msse2
++                sse2_compiler.commands += -msse2
++                sse2_compiler.commands += -msse2
+             } else {
+                 sse2_compiler.commands += -msse2
+             }
+@@ -190,8 +197,10 @@
+             ssse3_compiler.commands = $$QMAKE_CXX -c -Winline
+ 
+             mac {
+-                ssse3_compiler.commands += -Xarch_i386 -mssse3
+-                ssse3_compiler.commands += -Xarch_x86_64 -mssse3
++#                ssse3_compiler.commands += -Xarch_i386 -mssse3
++#                ssse3_compiler.commands += -Xarch_x86_64 -mssse3
++                ssse3_compiler.commands += -mssse3
++                ssse3_compiler.commands += -mssse3
+             } else {
+                 ssse3_compiler.commands += -mssse3
+             }

--- a/pyqt4.cmake
+++ b/pyqt4.cmake
@@ -48,6 +48,7 @@ ExternalProject_Add(${pyqt4_NAME}
     URL                 ${pyqt4_URL}
     URL_MD5             ${pyqt4_MD5}
     UPDATE_COMMAND      ""
+    # New patch related to new version of PyQt4, which still suffers from the same phonon bug.
     PATCH_COMMAND       ${BUILDEM_ENV_STRING} ${PATCH_EXE}
         ${pyqt4_SRC_DIR}/configure.py ${PATCH_DIR}/pyqt4.patch # For some reason, the configure script wants to build pyqt phonon support even if qt was built without it.  This patch simply comments out phonon support.
     CONFIGURE_COMMAND   ${BUILDEM_ENV_STRING} PYTHONPATH=${BUILDEM_PYTHONPATH} ${PYTHON_EXE} ${pyqt4_SRC_DIR}/configure.py 

--- a/qt4.cmake
+++ b/qt4.cmake
@@ -46,6 +46,10 @@ ExternalProject_Add(${qt4_NAME}
     PATCH_COMMAND       ${BUILDEM_ENV_STRING} ${PATCH_EXE}
 			# This patch fixes ilastik crashes on OSX due to an ill-shaped ellipse
 			${qt4_SRC_DIR}/src/gui/painting/qpaintengine_mac.cpp ${PATCH_DIR}/qt4-osx-draw-ellipse.patch
+			# This patch fixes removes Xarch_x86_64 flags from the Qt4 configure file. These flags are not appropriate for Mavericks and cause Qt4 to fail building.
+			${qt4_SRC_DIR}/configure ${PATCH_DIR}/qt4-osx-mavericks-configure.patch
+			# This patch fixes removes Xarch_x86_64 flags from the Qt4 gui.pro file. These flags are not appropriate for Mavericks and cause Qt4 to fail building.
+			${qt4_SRC_DIR}/src/gui/gui.pro ${PATCH_DIR}/qt4-osx-mavericks-gui-pro.patch
     CONFIGURE_COMMAND   ${BUILDEM_ENV_STRING} env CXXFLAGS=${BUILDEM_ADDITIONAL_CXX_FLAGS} echo "yes" | ${qt4_SRC_DIR}/configure # pipe "yes" to stdin to accept the license.
         --prefix=${BUILDEM_DIR}
         -opensource

--- a/sip.cmake
+++ b/sip.cmake
@@ -34,12 +34,18 @@ ExternalProject_Add(${sip_NAME}
     UPDATE_COMMAND      ""
     PATCH_COMMAND       ""
     LIST_SEPARATOR      ^^
+    # Though it may seem that the -b, -d, -e, and -v flags are unnecessary, this is not the case.
+    # It would seem obvious that the install would happen in those locations. However, python will
+    # become confused if the system python has SIP installed. Thus, keeping the flags below will
+    # ensure that the right SIP packages can be imported by python. This is necessary for the build
+    # of qimage2ndarray in particular. Without the flags below, qimage2ndarray will fail to find the
+    # right SIP to build with.
     CONFIGURE_COMMAND   ${BUILDEM_ENV_STRING} ${PYTHON_EXE} ${sip_SRC_DIR}/configure.py 
         ${EXTRA_SIP_CONFIG_FLAGS}
-        #-b ${PYTHON_PREFIX}/bin
-        #-d ${PYTHON_PREFIX}/lib/python2.7/site-packages
-        #-e ${PYTHON_PREFIX}/include/python2.7
-        #-v ${PYTHON_PREFIX}/share/sip
+        -b ${PYTHON_PREFIX}/bin
+        -d ${PYTHON_PREFIX}/lib/python2.7/site-packages
+        -e ${PYTHON_PREFIX}/include/python2.7
+        -v ${PYTHON_PREFIX}/share/sip
         
     BUILD_COMMAND       ${BUILDEM_ENV_STRING} $(MAKE)
     INSTALL_COMMAND     ${BUILDEM_ENV_STRING} $(MAKE) install


### PR DESCRIPTION
Carsten,

Sorry I didn't send these sooner. These are the changes that I have made to the fix/OSX10.9 branch to get it to build on my machine. I added a patch from lemon's page to fix an issue in the version used (should work on all OSes). PyQt was still looking for phonon even though it wasn't being built by Qt4 (should work on all OSes). So, I included a patch to fix this. For OpenBLAS, I have added TARGET=SANDYBRIDGE. This will make sure it builds properly on SandyBridge and Haswell (also Crystalwell). Though, it does not necessarily work on other processors. Qt4 couldn't build due to the Xarch_x86_64. This flag is not used in a compatible way on Mavericks. I commented them. However, it may not have the desired effect on other Mac versions. Finally, SIP had certain flags commented that cannot be lest it clash with a system version of SIP. I uncommented them (should work on all OSes).
